### PR TITLE
Update for Stardew 1.6

### DIFF
--- a/StardewValleyMods/CheaperBeachBridgeRepair/BeachPatches.cs
+++ b/StardewValleyMods/CheaperBeachBridgeRepair/BeachPatches.cs
@@ -24,7 +24,7 @@ namespace CheaperBeachBridgeRepair
                 {
                     case "BeachBridge_Yes":
                         Game1.globalFadeToBlack(new Game1.afterFadeFunction(__instance.fadedForBridgeFix), 0.02f);
-                        Game1.player.removeItemsFromInventory(388, _config.BridgeRepairPrice);
+                        Game1.player.Items.ReduceId("388", _config.BridgeRepairPrice);
                         __result = true;
                         return false;
                     default:
@@ -44,7 +44,7 @@ namespace CheaperBeachBridgeRepair
             {
                 if (__instance.map.GetLayer("Buildings").Tiles[tileLocation] != null && __instance.map.GetLayer("Buildings").Tiles[tileLocation].TileIndex == 284)
                 {
-                    if (who.hasItemInInventory(388, _config.BridgeRepairPrice, 0))
+                    if (who.Items.ContainsId("388", _config.BridgeRepairPrice))
                     {
                         __instance.createQuestionDialogue(Game1.content.LoadString("Strings\\Locations:Beach_FixBridge_Question").Replace("300", _config.BridgeRepairPrice.ToString()), __instance.createYesNoResponses(), "BeachBridge");
                     }

--- a/StardewValleyMods/CheaperBeachBridgeRepair/CheaperBeachBridgeRepair.cs
+++ b/StardewValleyMods/CheaperBeachBridgeRepair/CheaperBeachBridgeRepair.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 
 namespace CheaperBeachBridgeRepair
@@ -7,7 +7,7 @@ namespace CheaperBeachBridgeRepair
     {
         public override void Entry(IModHelper helper)
         {
-            var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
+            var harmony = new Harmony(ModManifest.UniqueID);
             BeachPatches.Initialize(Helper.ReadConfig<ModConfig>(), Monitor);
 
             harmony.Patch(

--- a/StardewValleyMods/CheaperBeachBridgeRepair/CheaperBeachBridgeRepair.csproj
+++ b/StardewValleyMods/CheaperBeachBridgeRepair/CheaperBeachBridgeRepair.csproj
@@ -1,68 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FB11AEDF-CAFA-4B7B-BBD7-2BBC6678530A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>CheaperBeachBridgeRepair</RootNamespace>
-    <AssemblyName>CheaperBeachBridgeRepair</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <EnableHarmony>true</EnableHarmony>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BeachPatches.cs" />
-    <Compile Include="CheaperBeachBridgeRepair.cs" />
-    <Compile Include="ModConfig.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="manifest.json" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>CheaperBeachBridgeRepair</AssemblyName>
+		<RootNamespace>CheaperBeachBridgeRepair</RootNamespace>
+		<Version>1.1.1</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>Latest</LangVersion>
+		<EnableHarmony>True</EnableHarmony>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+	</ItemGroup>
 </Project>

--- a/StardewValleyMods/CheaperBeachBridgeRepair/manifest.json
+++ b/StardewValleyMods/CheaperBeachBridgeRepair/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Cheaper Beach Bridge Repair",
   "Author": "Annosz",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Makes repairing the bridge on the beach cheaper.",
   "UniqueID": "Annosz.CheaperBeachBridgeRepair",
   "EntryDll": "CheaperBeachBridgeRepair.dll",

--- a/StardewValleyMods/HighlightedJars/HighlightedJars.cs
+++ b/StardewValleyMods/HighlightedJars/HighlightedJars.cs
@@ -1,13 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Netcode;
-using Newtonsoft.Json.Linq;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
-using StardewValley.Menus;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace HighlightedJars
@@ -42,10 +39,10 @@ namespace HighlightedJars
                 return;
 
             var highlightableObjects = Game1.currentLocation.objects.Values.Where(o =>
-                ((Config.HighlightJars && (o as StardewValley.Object).parentSheetIndex == 15)
-                    || (Config.HighlightKegs && (o as StardewValley.Object).parentSheetIndex == 12)
-                    || (Config.HighlightCasks && (o as StardewValley.Object).parentSheetIndex == 163))
-                && o.minutesUntilReady <= 0 && !o.readyForHarvest
+                ((Config.HighlightJars && o.ParentSheetIndex == 15)
+                    || (Config.HighlightKegs && o.ParentSheetIndex == 12)
+                    || (Config.HighlightCasks && o.ParentSheetIndex == 163))
+                && o.MinutesUntilReady <= 0 && !o.readyForHarvest.Value
                 ).ToList();
 
             foreach (var highlightableObject in highlightableObjects)
@@ -56,7 +53,7 @@ namespace HighlightedJars
                 switch (Config.HighlightType)
                 {
                     case "Highlight":
-                        e.SpriteBatch.Draw(Game1.bigCraftableSpriteSheet, new Vector2(local.X + 32, local.Y + 32), new Rectangle?(StardewValley.Object.getSourceRectForBigCraftable((int)(NetFieldBase<int, NetInt>)highlightableObject.parentSheetIndex)), Color.Red * 0.50f, 0.0f, new Vector2(8f, 8f), 4f, SpriteEffects.None, (float)((highlightableObject.TileLocation.Y - 1) * 64) / 10000f);
+                        e.SpriteBatch.Draw(Game1.bigCraftableSpriteSheet, new Vector2(local.X + 32, local.Y + 32), new Rectangle?(StardewValley.Object.getSourceRectForBigCraftable(highlightableObject.ParentSheetIndex)), Color.Red * 0.50f, 0.0f, new Vector2(8f, 8f), 4f, SpriteEffects.None, (float)((highlightableObject.TileLocation.Y - 1) * 64) / 10000f);
                         break;
                     case "Bubble":
                     default:

--- a/StardewValleyMods/HighlightedJars/HighlightedJars.cs
+++ b/StardewValleyMods/HighlightedJars/HighlightedJars.cs
@@ -1,66 +1,172 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Netcode;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using SObject = StardewValley.Object;
 
 namespace HighlightedJars
 {
     public class HighlightedJars : Mod
     {
-        private ModConfig Config;
+        private const int ExclamationEmoteIndex = 16;
 
-        private const int exclamationEmote = 16;
+        private static readonly Lazy<Rectangle> ExclamationEmoteSourceRect =
+            new(() =>
+                new Rectangle(
+                    ExclamationEmoteIndex * 16 % Game1.emoteSpriteSheet.Width,
+                    ExclamationEmoteIndex * 16 / Game1.emoteSpriteSheet.Width * 16,
+                    16,
+                    16));
+
+        private readonly PerScreen<HighlightData> dataPerScreen = new();
+
+        private ModConfig config;
 
         public override void Entry(IModHelper helper)
         {
-            Config = Helper.ReadConfig<ModConfig>();
+            config = Helper.ReadConfig<ModConfig>();
 
-            helper.Events.GameLoop.SaveLoaded += (s, e) => GameLoop_SaveLoaded(s, e, helper);
-            helper.Events.GameLoop.ReturnedToTitle += (s, e) => GameLoop_ReturnedToTitle(s, e, helper);
-        }
-
-        private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e, IModHelper helper)
-        {
-            helper.Events.Display.RenderedWorld += Display_RenderedWorld;
-        }
-
-        private void GameLoop_ReturnedToTitle(object sender, ReturnedToTitleEventArgs e, IModHelper helper)
-        {
-            helper.Events.Display.RenderedWorld -= Display_RenderedWorld;
+            helper.Events.GameLoop.DayStarted += GameLoop_DayStarted;
+            helper.Events.GameLoop.SaveLoaded += GameLoop_SaveLoaded;
+            helper.Events.GameLoop.ReturnedToTitle += GameLoop_ReturnedToTitle;
+            helper.Events.Player.Warped += Player_Warped;
+            helper.Events.World.ObjectListChanged += World_ObjectListChanged;
         }
 
         private void Display_RenderedWorld(object sender, RenderedWorldEventArgs e)
         {
-            if (Game1.currentLocation == null)
-                return;
-
-            var highlightableObjects = Game1.currentLocation.objects.Values.Where(o =>
-                ((Config.HighlightJars && o.ParentSheetIndex == 15)
-                    || (Config.HighlightKegs && o.ParentSheetIndex == 12)
-                    || (Config.HighlightCasks && o.ParentSheetIndex == 163))
-                && o.MinutesUntilReady <= 0 && !o.readyForHarvest.Value
-                ).ToList();
-
-            foreach (var highlightableObject in highlightableObjects)
+            if (!dataPerScreen.IsActiveForScreen())
             {
-                Vector2 local = Game1.GlobalToLocal(Game1.viewport, new Vector2((float)(highlightableObject.TileLocation.X * 64), (float)(Math.Abs(highlightableObject.TileLocation.Y * 64 - 64))));
-                Rectangle destinationRectangle = new Rectangle((int)local.X, (int)local.Y - 32, 64, 64);
+                return;
+            }
 
-                switch (Config.HighlightType)
+            var data = dataPerScreen.Value;
+            if (data.Location != Game1.currentLocation)
+            {
+                // This should never happen if the events are set up properly. But if it does, don't draw nonsense.
+                return;
+            }
+            foreach (var obj in dataPerScreen.Value.HighlightableObjects)
+            {
+                if (ShouldHighlight(obj))
                 {
-                    case "Highlight":
-                        e.SpriteBatch.Draw(Game1.bigCraftableSpriteSheet, new Vector2(local.X + 32, local.Y + 32), new Rectangle?(StardewValley.Object.getSourceRectForBigCraftable(highlightableObject.ParentSheetIndex)), Color.Red * 0.50f, 0.0f, new Vector2(8f, 8f), 4f, SpriteEffects.None, (float)((highlightableObject.TileLocation.Y - 1) * 64) / 10000f);
-                        break;
-                    case "Bubble":
-                    default:
-                        e.SpriteBatch.Draw(Game1.emoteSpriteSheet, destinationRectangle, new Rectangle(exclamationEmote * 16 % Game1.emoteSpriteSheet.Width, exclamationEmote * 16 / Game1.emoteSpriteSheet.Width * 16, 16, 16), Color.White * 0.95f, 0.0f, Vector2.Zero, SpriteEffects.None, (float)((highlightableObject.TileLocation.Y - 1) * 64) / 10000f);
-                        break;
+                    DrawHighlight(e.SpriteBatch, obj);
                 }
             }
         }
+
+        private void GameLoop_DayStarted(object sender, DayStartedEventArgs e)
+        {
+            ReloadForLocation(Game1.currentLocation);
+        }
+
+        private void GameLoop_ReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
+        {
+            Helper.Events.Display.RenderedWorld -= Display_RenderedWorld;
+            dataPerScreen.ResetAllScreens();
+        }
+
+        private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            Helper.Events.Display.RenderedWorld += Display_RenderedWorld;
+        }
+
+        private void Player_Warped(object sender, WarpedEventArgs e)
+        {
+            ReloadForLocation(e.NewLocation);
+        }
+
+        private void World_ObjectListChanged(object sender, ObjectListChangedEventArgs e)
+        {
+            foreach (var (_, data) in dataPerScreen.GetActiveValues())
+            {
+                if (e.Location != data.Location)
+                {
+                    continue;
+                }
+                foreach (var removed in e.Removed)
+                {
+                    data.HighlightableObjects.Remove(removed.Value);
+                }
+                foreach (var added in e.Added)
+                {
+                    data.HighlightableObjects.Add(added.Value);
+                }
+            }
+        }
+
+        private static bool CanHighlight(string qualifiedItemId)
+        {
+            return qualifiedItemId == "(BC)12" || qualifiedItemId == "(BC)15" || qualifiedItemId == "(BC)163";
+        }
+
+        private void DrawHighlight(SpriteBatch b, SObject obj)
+        {
+            var local = Game1.GlobalToLocal(
+                Game1.viewport,
+                new Vector2((obj.TileLocation.X * 64), (float)(Math.Abs(obj.TileLocation.Y * 64 - 64))));
+            switch (config.HighlightType)
+            {
+                case HighlightType.Highlight:
+                    b.Draw(
+                        Game1.bigCraftableSpriteSheet,
+                        position: new Vector2(local.X + 32, local.Y + 32),
+                        sourceRectangle: SObject.getSourceRectForBigCraftable(obj.ParentSheetIndex),
+                        color: Color.Red * 0.50f,
+                        rotation: 0.0f,
+                        origin: new Vector2(8f, 8f),
+                        scale: 4f,
+                        effects: SpriteEffects.None,
+                        layerDepth: ((obj.TileLocation.Y - 1) * 64) / 10000f);
+                    break;
+                case HighlightType.Bubble:
+                default:
+                    var destinationRect = new Rectangle((int)local.X, (int)local.Y - 32, 64, 64);
+                    b.Draw(
+                        Game1.emoteSpriteSheet,
+                        destinationRect,
+                        sourceRectangle: ExclamationEmoteSourceRect.Value,
+                        color: Color.White * 0.95f,
+                        rotation: 0.0f,
+                        origin: Vector2.Zero,
+                        effects: SpriteEffects.None,
+                        layerDepth: ((obj.TileLocation.Y - 1) * 64) / 10000f);
+                    break;
+            }
+        }
+
+        private static IEnumerable<SObject> GetHighlightableObjects(GameLocation location)
+        {
+            return location.objects.Values.Where(obj => CanHighlight(obj.QualifiedItemId));
+        }
+
+        private void ReloadForLocation(GameLocation location)
+        {
+            var highlightableObjects = GetHighlightableObjects(location);
+            dataPerScreen.Value = new(location, highlightableObjects);
+        }
+
+        private bool ShouldHighlight(SObject obj)
+        {
+            var isConfiguredForHighlight = obj.QualifiedItemId switch
+            {
+                "(BC)12" => config.HighlightKegs,
+                "(BC)15" => config.HighlightJars,
+                "(BC)163" => config.HighlightCasks,
+                _ => false,
+            };
+            return isConfiguredForHighlight && obj.MinutesUntilReady <= 0 && !obj.readyForHarvest.Value;
+        }
+    }
+
+    class HighlightData(GameLocation location, IEnumerable<SObject> initialHighlightableObjects)
+    {
+        public GameLocation Location { get; } = location;
+        public HashSet<SObject> HighlightableObjects { get; } = [.. initialHighlightableObjects];
     }
 }

--- a/StardewValleyMods/HighlightedJars/HighlightedJars.csproj
+++ b/StardewValleyMods/HighlightedJars/HighlightedJars.csproj
@@ -1,70 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1FFDE1D7-E092-4CC8-A195-B4A1CE31BCBB}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>HighlightedJars</RootNamespace>
-    <AssemblyName>HighlightedJars</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="HighlightedJars.cs" />
-    <Compile Include="ModConfig.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>HighlightedJars</AssemblyName>
+		<RootNamespace>HighlightedJars</RootNamespace>
+		<Version>1.0.1</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>Latest</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+	</ItemGroup>
 </Project>

--- a/StardewValleyMods/HighlightedJars/ModConfig.cs
+++ b/StardewValleyMods/HighlightedJars/ModConfig.cs
@@ -1,8 +1,14 @@
 ﻿namespace HighlightedJars
 {
+    public enum HighlightType
+    {
+        Highlight,
+        Bubble,
+    }
+
     public class ModConfig
     {
-        public string HighlightType { get; set; } = "Highlight";
+        public HighlightType HighlightType { get; set; } = HighlightType.Highlight;
 
         public bool HighlightJars { get; set; } = true;
         public bool HighlightKegs { get; set; } = true;

--- a/StardewValleyMods/HighlightedJars/ModConfig.cs
+++ b/StardewValleyMods/HighlightedJars/ModConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace HighlightedJars
+﻿namespace HighlightedJars
 {
     public class ModConfig
     {

--- a/StardewValleyMods/HighlightedJars/manifest.json
+++ b/StardewValleyMods/HighlightedJars/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Highlighted Jars",
   "Author": "Annosz",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "Jars, kegs and casks are highlighted when empty to be easily recognizable.",
   "UniqueID": "Annosz.HighlightedJars",
   "EntryDll": "HighlightedJars.dll",

--- a/StardewValleyMods/HighlightedJars/packages.config
+++ b/StardewValleyMods/HighlightedJars/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
-</packages>

--- a/StardewValleyMods/KrobusSellsLargerStacks/KrobusItem.cs
+++ b/StardewValleyMods/KrobusSellsLargerStacks/KrobusItem.cs
@@ -1,21 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace KrobusSellsLargerStacks
+﻿namespace KrobusSellsLargerStacks
 {
     public class KrobusItem
     {
         public int ItemQuantity { get; set; }
-        public int ItemId { get; set; }
+        public string QualifiedItemId { get; set; }
         public string Type { get; set; }
 
-        public KrobusItem(int itemQuantity, int itemId = 0, string type = "")
+        public KrobusItem(int itemQuantity, string qualifiedItemId = "", string type = "")
         {
             ItemQuantity = itemQuantity;
-            ItemId = itemId;
+            QualifiedItemId = qualifiedItemId;
             Type = type;
         }
     }

--- a/StardewValleyMods/KrobusSellsLargerStacks/KrobusSellsLargerStacks.cs
+++ b/StardewValleyMods/KrobusSellsLargerStacks/KrobusSellsLargerStacks.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
@@ -26,15 +25,15 @@ namespace KrobusSellsLargerStacks
             {
                 foreach (var krobusItem in GetKrobusItemsFromConfig(Config))
                 {
-                    KeyValuePair<ISalable, int[]>  sellable = GetSellable(menu, krobusItem);
+                    KeyValuePair<ISalable, ItemStockInformation>  sellable = GetSellable(menu, krobusItem);
 
-                    if (!sellable.Equals(new KeyValuePair<ISalable, int[]>()))
+                    if (!sellable.Equals(new KeyValuePair<ISalable, ItemStockInformation>()))
                     {
                         var sellableItem = sellable.Key;
                         var priceAndStock = sellable.Value;
 
                         sellableItem.Stack = krobusItem.ItemQuantity;
-                        priceAndStock[priceAndStock.Length - 1] = krobusItem.ItemQuantity;
+                        priceAndStock.Stock = krobusItem.ItemQuantity;
                         menu.itemPriceAndStock[sellableItem] = priceAndStock;
                     }
 
@@ -88,9 +87,9 @@ namespace KrobusSellsLargerStacks
             return krobusItems;
         }
 
-        private static KeyValuePair<ISalable, int[]> GetSellable(ShopMenu menu, KrobusItem krobusItem)
+        private static KeyValuePair<ISalable, ItemStockInformation> GetSellable(ShopMenu menu, KrobusItem krobusItem)
         {
-            KeyValuePair<ISalable, int[]> sellable = new KeyValuePair<ISalable, int[]>();
+            KeyValuePair<ISalable, ItemStockInformation> sellable = new KeyValuePair<ISalable, ItemStockInformation>();
 
             try
             {

--- a/StardewValleyMods/KrobusSellsLargerStacks/KrobusSellsLargerStacks.csproj
+++ b/StardewValleyMods/KrobusSellsLargerStacks/KrobusSellsLargerStacks.csproj
@@ -1,71 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{5414AB1A-4320-4E5A-B553-FFAF9C388E61}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>KrobusSellsLargerStacks</RootNamespace>
-    <AssemblyName>KrobusSellsLargerStacks</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="KrobusItem.cs" />
-    <Compile Include="KrobusSellsLargerStacks.cs" />
-    <Compile Include="ModConfig.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="manifest.json" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>KrobusSellsLargerStacks</AssemblyName>
+		<RootNamespace>KrobusSellsLargerStacks</RootNamespace>
+		<Version>1.0.1</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>Latest</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+	</ItemGroup>
 </Project>

--- a/StardewValleyMods/KrobusSellsLargerStacks/ModConfig.cs
+++ b/StardewValleyMods/KrobusSellsLargerStacks/ModConfig.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace KrobusSellsLargerStacks
+﻿namespace KrobusSellsLargerStacks
 {
     public class ModConfig
     {

--- a/StardewValleyMods/KrobusSellsLargerStacks/manifest.json
+++ b/StardewValleyMods/KrobusSellsLargerStacks/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Krobus Sells Larger Stacks",
   "Author": "Annosz",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "Krobus's shop sells items in larger stacks, making it easier to buy large quantities of the same products.",
   "UniqueID": "Annosz.KrobusSellsLargerStacks",
   "EntryDll": "KrobusSellsLargerStacks.dll",

--- a/StardewValleyMods/KrobusSellsLargerStacks/packages.config
+++ b/StardewValleyMods/KrobusSellsLargerStacks/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
-</packages>

--- a/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.cs
+++ b/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 
 namespace RememberFacedDirection
@@ -7,7 +7,7 @@ namespace RememberFacedDirection
     {
         public override void Entry(IModHelper helper)
         {
-            var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
+            var harmony = new Harmony(ModManifest.UniqueID);
             RememberFacedDirectionPatches.Initialize(Monitor);
 
             harmony.Patch(

--- a/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.csproj
+++ b/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.csproj
@@ -1,67 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2B81C3D0-4ABA-4F0D-9743-838201FBF3B4}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>RememberFacedDirection</RootNamespace>
-    <AssemblyName>RememberFacedDirection</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <EnableHarmony>true</EnableHarmony>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="RememberFacedDirectionPatches.cs" />
-    <Compile Include="RememberFacedDirection.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="manifest.json" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>RememberFacedDirection</AssemblyName>
+		<RootNamespace>RememberFacedDirection</RootNamespace>
+		<Version>1.0.1</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>Latest</LangVersion>
+		<EnableHarmony>True</EnableHarmony>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+	</ItemGroup>
 </Project>

--- a/StardewValleyMods/RememberFacedDirection/manifest.json
+++ b/StardewValleyMods/RememberFacedDirection/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Remember Faced Direction",
   "Author": "Annosz",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Description": "Makes the farmer turn back to his previous direction after eating, getting a special item and other actions.",
   "UniqueID": "Annosz.RememberFacedDirection",
   "EntryDll": "RememberFacedDirection.dll",

--- a/StardewValleyMods/SleeplessFisherman/FarmerPatches.cs
+++ b/StardewValleyMods/SleeplessFisherman/FarmerPatches.cs
@@ -2,10 +2,6 @@
 using StardewValley;
 using StardewValley.Tools;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SleeplessFisherman
 {
@@ -22,8 +18,10 @@ namespace SleeplessFisherman
         {
             try
             {
-                if ((__instance is Farmer) && ((__instance as Farmer).CurrentTool is FishingRod)
-                    && ((__instance as Farmer).CurrentTool as FishingRod).isFishing && whichEmote == 24)
+                if ((__instance is Farmer farmer
+                    && farmer.CurrentTool is FishingRod fishingRod
+                    && fishingRod.isFishing
+                    && whichEmote == 24))
                     return false;
                 return true;
             }

--- a/StardewValleyMods/SleeplessFisherman/SleeplessFisherman.cs
+++ b/StardewValleyMods/SleeplessFisherman/SleeplessFisherman.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
 using System;
 
@@ -8,7 +8,7 @@ namespace SleeplessFisherman
     {
         public override void Entry(IModHelper helper)
         {
-            var harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
+            var harmony = new Harmony(ModManifest.UniqueID);
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(StardewValley.Farmer), nameof(StardewValley.Farmer.doEmote), new Type[] { typeof(int) }),

--- a/StardewValleyMods/SleeplessFisherman/SleeplessFisherman.csproj
+++ b/StardewValleyMods/SleeplessFisherman/SleeplessFisherman.csproj
@@ -1,67 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B2F92A93-F038-4FAD-97C5-858E1A1624CC}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>SleeplessFisherman</RootNamespace>
-    <AssemblyName>SleeplessFisherman</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-    <EnableHarmony>true</EnableHarmony>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="FarmerPatches.cs" />
-    <Compile Include="SleeplessFisherman.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="manifest.json" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<AssemblyName>SleeplessFisherman</AssemblyName>
+		<RootNamespace>SleeplessFisherman</RootNamespace>
+		<Version>1.0.2</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<LangVersion>Latest</LangVersion>
+		<EnableHarmony>True</EnableHarmony>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
+	</ItemGroup>
 </Project>

--- a/StardewValleyMods/SleeplessFisherman/manifest.json
+++ b/StardewValleyMods/SleeplessFisherman/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Sleepless Fisherman",
   "Author": "Annosz",
-  "Version": "1.0.1",
+  "Version": "1.0.2",
   "Description": "Disables sleep emote at 12AM and 1AM if the player is fishing.",
   "UniqueID": "Annosz.SleeplessFisherman",
   "EntryDll": "SleeplessFisherman.dll",


### PR DESCRIPTION
For some mods the changes are minor, others are more significant.

- All projects are updated to use the .NET Project SDK instead of the legacy/deprecated format.
- Update to the latest SMAPI/`ModBuildConfig` package.
- Deprecated/removed fields, netfields and methods are replaced with their new equivalents.
- Use qualified item IDs where possible.
- Fixed some significant performance problems in Highlighted Jars, and minor perf issues + potentially buggy behavior in the Krobus mod.
- Various minor cleanup tasks like removing unused `using` directives.