### PR TITLE
Fix crash caused by ambiguous holdUpItemThenMessage patch

### DIFF
--- a/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.cs
+++ b/StardewValleyMods/RememberFacedDirection/RememberFacedDirection.cs
@@ -15,7 +15,7 @@ namespace RememberFacedDirection
                prefix: new HarmonyMethod(typeof(RememberFacedDirectionPatches), nameof(RememberFacedDirectionPatches.Game1_PressActionButton_Prefix))
             );
             harmony.Patch(
-               original: AccessTools.Method(typeof(StardewValley.Farmer), nameof(StardewValley.Farmer.holdUpItemThenMessage)),
+               original: AccessTools.Method(typeof(StardewValley.Farmer), nameof(StardewValley.Farmer.holdUpItemThenMessage), new[] { typeof(StardewValley.Item), typeof(int), typeof(bool) }),
                prefix: new HarmonyMethod(typeof(RememberFacedDirectionPatches), nameof(RememberFacedDirectionPatches.Farmer_HoldUpItemThenMessage_Prefix))
             );
 

--- a/StardewValleyMods/RememberFacedDirection/manifest.json
+++ b/StardewValleyMods/RememberFacedDirection/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Remember Faced Direction",
   "Author": "Annosz",
-  "Version": "1.0.1",
+  "Version": "1.1.2",
   "Description": "Makes the farmer turn back to his previous direction after eating, getting a special item and other actions.",
   "UniqueID": "Annosz.RememberFacedDirection",
   "EntryDll": "RememberFacedDirection.dll",


### PR DESCRIPTION
The method now has an overload and needs to be disambiguated by specifying the parameters of the version that contains the actual functionality, which is just wrapped by the other overload. You'll probably want to bump the version to "1.1.2" and release a new build on Nexusmods.

Here's how it crashed on SMAPI 4.3.2 with Stardew Valley 1.6.15:
<img width="1458" height="353" alt="image" src="https://github.com/user-attachments/assets/79e52190-a568-4609-9d76-0cbacd614cb8" />
